### PR TITLE
feat: Implement profile-specific AI prompts

### DIFF
--- a/lua/prompts/default.lua
+++ b/lua/prompts/default.lua
@@ -1,0 +1,2 @@
+-- lua/prompts/default.lua
+return "You are a helpful general-purpose AI assistant. Please provide clear and concise answers."

--- a/lua/prompts/elixir.lua
+++ b/lua/prompts/elixir.lua
@@ -1,0 +1,2 @@
+-- lua/prompts/elixir.lua
+return "You are an expert Elixir programmer. Please provide concise and accurate assistance for Elixir-related questions. Focus on functional programming principles, concurrency, and OTP."

--- a/lua/prompts/python.lua
+++ b/lua/prompts/python.lua
@@ -1,0 +1,2 @@
+-- lua/prompts/python.lua
+return "You are an expert Python programmer. Please provide concise and accurate assistance for Python-related questions. Focus on best practices and idiomatic Python code."


### PR DESCRIPTION
- I modified init.lua to dynamically load and set system prompts for avante.nvim based on the current Neovim profile.
- I added a `load_and_set_ai_prompt(profile_name)` function in init.lua which attempts to load a prompt from `lua/prompts/<profile_name>.lua`.
- If a specific prompt is found, it's set using `avante.config.override()`.
- I made calls to this function when changing profiles and during initial profile load.
- I created the `lua/prompts/` directory.
- I added example prompt files: `lua/prompts/python.lua`, `lua/prompts/elixir.lua`, and `lua/prompts/default.lua`.

This allows you to define different system prompts for the AI based on your active Neovim (language) profile.